### PR TITLE
Fix node-arch sniffing for node 0.6 and to use the correct node.

### DIFF
--- a/libusdt-build.sh
+++ b/libusdt-build.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -o errexit
+
 # GYP's MAKEFLAGS confuses libusdt's Makefile
 #
 unset MAKEFLAGS
@@ -10,7 +12,15 @@ unset MAKEFLAGS
 # node extensions universal on the Mac - for now we'll go with x86_64
 # on a 64 bit Mac)
 #
-ARCH=`node -e "console.log(process.config.variables.target_arch == 'x64' ? 'x86_64' : 'i386')"`
+# libusdt/Makefile wants ARCH to be either 'x86_64' or 'i386'.
+NODE_ARCH=$(file $npm_config_prefix/bin/node | awk '{print $3}')
+if [[ "$NODE_ARCH" == "32-bit" ]]; then
+    ARCH=i386
+elif [[ "$NODE_ARCH" == "64-bit" ]]; then
+    ARCH=x86_64
+else
+    echo "ERROR: unknown arch for $npm_config_prefix/bin/node: '$NODE_ARCH'"
+fi
 echo "Building libusdt for ${ARCH}"
 export ARCH
 


### PR DESCRIPTION
- Use npm_config_prefix to use the node invoking this npm
- node < 0.8 doesn't have 'process.config'

Hi Chris,

Without this patch the "ARCH=" sniffing would blow up with node 0.6, resulting in a fallback to 'isainfo -k' arch... which in my case was 64-bit when the relevant node build was 32-bit -> boom.
