### PR TITLE
fix build on Mac broken in issue #28 with gmake default

### DIFF
--- a/libusdt-build.sh
+++ b/libusdt-build.sh
@@ -21,7 +21,12 @@ export ARCH
 
 # Respect a MAKE variable if set
 if [ -z $MAKE ]; then
-  MAKE=gmake
+  # Default to `gmake` first if available, because we require GNU make
+  # and `make` isn't GNU make on some plats.
+  MAKE=`which gmake`
+  if [ -z $MAKE ]; then
+    MAKE=make
+  fi
 fi
 
 # Build.


### PR DESCRIPTION
With the change for issue #28, install on Mac breaks because Mac's `make` is GNU make, but there is no gmake.

```
$ npm install dtrace-provider@0.2.5
npm http GET https://registry.npmjs.org/dtrace-provider/0.2.5
npm http 304 https://registry.npmjs.org/dtrace-provider/0.2.5

> dtrace-provider@0.2.5 install /Users/trentm/tmp/p/node_modules/dtrace-provider
> node-gyp rebuild

  ACTION binding_gyp_libusdt_target_build_libusdt .
Building libusdt for x86_64
libusdt-build.sh: line 29: gmake: command not found
make: *** [.] Error 127
gyp ERR! build error 
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/Users/trentm/opt/node-0.8.14/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:236:23)
gyp ERR! stack     at ChildProcess.EventEmitter.emit (events.js:99:17)
gyp ERR! stack     at Process._handle.onexit (child_process.js:678:10)
gyp ERR! System Darwin 10.8.0
gyp ERR! command "node" "/Users/trentm/opt/node-0.8.14/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /Users/trentm/tmp/p/node_modules/dtrace-provider
gyp ERR! node -v v0.8.14
gyp ERR! node-gyp -v v0.7.1
gyp ERR! not ok 
npm ERR! dtrace-provider@0.2.5 install: `node-gyp rebuild`
npm ERR! `sh "-c" "node-gyp rebuild"` failed with 1
npm ERR! 
npm ERR! Failed at the dtrace-provider@0.2.5 install script.
npm ERR! This is most likely a problem with the dtrace-provider package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     node-gyp rebuild
npm ERR! You can get their info via:
npm ERR!     npm owner ls dtrace-provider
npm ERR! There is likely additional logging output above.

npm ERR! System Darwin 10.8.0
npm ERR! command "/Users/trentm/opt/node-0.8.14/bin/node" "/Users/trentm/opt/node-0.8/bin/npm" "install" "dtrace-provider@0.2.5"
npm ERR! cwd /Users/trentm/tmp/p
npm ERR! node -v v0.8.14
npm ERR! npm -v 1.1.65
npm ERR! code ELIFECYCLE
npm ERR! 
npm ERR! Additional logging details can be found in:
npm ERR!     /Users/trentm/tmp/p/npm-debug.log
npm ERR! not ok code 0
```
