### PR TITLE
Write error to stderr

### DIFF
--- a/dtrace-provider.js
+++ b/dtrace-provider.js
@@ -22,7 +22,7 @@ for (var i in builds) {
         if (process.platform == 'darwin' ||
             process.platform == 'solaris' ||
             process.platform == 'freebsd') {
-            console.log(e);
+            process.stderr.write(e + '\n');
         }
     }
 }


### PR DESCRIPTION
Tools (Bunyan and Restify) use dtrace-provider heavily and in the case of bunyan, if this error is written to stdout along with json, the result is invalid json.

A fine example where this error needs to be in stderr vs stdout

```
bunyan LOGFILE | json -ga field.name
```
