### PR TITLE
createDTraceProvider now uses the exported provider

### DIFF
--- a/dtrace-provider.js
+++ b/dtrace-provider.js
@@ -7,6 +7,7 @@ DTraceProviderStub.prototype.addProbe = function() {
     };
 };
 DTraceProviderStub.prototype.enable = function() {};
+DTraceProviderStub.prototype.disable = function() {};
 DTraceProviderStub.prototype.fire = function() {};
 
 var builds = ['Release', 'default', 'Debug'];


### PR DESCRIPTION
This allows for code to use the `createDTraceProvider` and for a test to override the provider used.  Otherwise, you are forced to `new dtraceProvider.DTraceProvider()` if you want a test to be able to change the provider (for intercepting the fire method).
