### PR TITLE
use NAN for Node 0.8->0.11+ compatibility

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -14,7 +14,8 @@
                         'dtrace_argument.cc'
                     ],
                     'include_dirs': [
-	                'libusdt'
+                        'libusdt',
+                        '<!(node -e "require(\'nan\')")'
                     ],
                     'dependencies': [
                         'libusdt'

--- a/dtrace_probe.cc
+++ b/dtrace_probe.cc
@@ -1,7 +1,5 @@
 #include "dtrace_provider.h"
-#include <v8.h>
-
-#include <node.h>
+#include <nan.h>
 
 namespace node {
 
@@ -21,31 +19,33 @@ namespace node {
   Persistent<FunctionTemplate> DTraceProbe::constructor_template;
 
   void DTraceProbe::Initialize(Handle<Object> target) {
-    HandleScope scope;
+    NanScope();
 
     Local<FunctionTemplate> t = FunctionTemplate::New(DTraceProbe::New);
-    constructor_template = Persistent<FunctionTemplate>::New(t);
-    constructor_template->InstanceTemplate()->SetInternalFieldCount(1);
-    constructor_template->SetClassName(String::NewSymbol("DTraceProbe"));
+    t->InstanceTemplate()->SetInternalFieldCount(1);
+    t->SetClassName(NanSymbol("DTraceProbe"));
+    NanAssignPersistent(FunctionTemplate, constructor_template, t);
 
-    NODE_SET_PROTOTYPE_METHOD(constructor_template, "fire", DTraceProbe::Fire);
+    NODE_SET_PROTOTYPE_METHOD(t, "fire", DTraceProbe::Fire);
 
-    target->Set(String::NewSymbol("DTraceProbe"), constructor_template->GetFunction());
+    target->Set(NanSymbol("DTraceProbe"), t->GetFunction());
   }
 
-  Handle<Value> DTraceProbe::New(const Arguments& args) {
+  NAN_METHOD(DTraceProbe::New) {
+    NanScope();
     DTraceProbe *probe = new DTraceProbe();
     probe->Wrap(args.This());
-    return args.This();
+    NanReturnValue(args.This());
   }
 
-  Handle<Value> DTraceProbe::Fire(const Arguments& args) {
-    HandleScope scope;
+  NAN_METHOD(DTraceProbe::Fire) {
+    NanScope();
     DTraceProbe *pd = ObjectWrap::Unwrap<DTraceProbe>(args.Holder());
-    return pd->_fire(args[0]);
+    NanReturnValue(pd->_fire(args[0]));
   }
 
   Handle<Value> DTraceProbe::_fire(v8::Local<v8::Value> argsfn) {
+    NanScope();
 
     if (usdt_is_enabled(this->probedef->probe) == 0) {
       return Undefined();
@@ -60,7 +60,7 @@ namespace node {
     }
 
     Local<Function> cb = Local<Function>::Cast(argsfn);
-    Local<Value> probe_args = cb->Call(this->handle_, 0, NULL);
+    Local<Value> probe_args = cb->Call(NanObjectWrapHandle(this), 0, NULL);
 
     // exception in args callback?
     if (try_catch.HasCaught()) {

--- a/dtrace_provider.h
+++ b/dtrace_provider.h
@@ -1,6 +1,5 @@
-#include <node.h>
+#include <nan.h>
 #include <node_object_wrap.h>
-#include <v8.h>
 
 extern "C" {
 #include <usdt.h>
@@ -58,7 +57,7 @@ namespace node {
     Persistent<Function> JSON_stringify;
   };
 
-  class DTraceProbe : ObjectWrap {
+  class DTraceProbe : public ObjectWrap {
 
   public:
     static void Initialize(v8::Handle<v8::Object> target);
@@ -66,8 +65,8 @@ namespace node {
     size_t argc;
     DTraceArgument *arguments[USDT_ARG_MAX];
 
-    static v8::Handle<v8::Value> New(const v8::Arguments& args);
-    static v8::Handle<v8::Value> Fire(const v8::Arguments& args);
+    static NAN_METHOD(New);
+    static NAN_METHOD(Fire);
 
     Handle<Value> _fire(v8::Local<v8::Value>);
 
@@ -78,18 +77,18 @@ namespace node {
   private:
   };
 
-  class DTraceProvider : ObjectWrap {
+  class DTraceProvider : public ObjectWrap {
 
   public:
     static void Initialize(v8::Handle<v8::Object> target);
     usdt_provider_t *provider;
 
-    static v8::Handle<v8::Value> New(const v8::Arguments& args);
-    static v8::Handle<v8::Value> AddProbe(const v8::Arguments& args);
-    static v8::Handle<v8::Value> RemoveProbe(const v8::Arguments& args);
-    static v8::Handle<v8::Value> Enable(const v8::Arguments& args);
-    static v8::Handle<v8::Value> Disable(const v8::Arguments& args);
-    static v8::Handle<v8::Value> Fire(const v8::Arguments& args);
+    static NAN_METHOD(New);
+    static NAN_METHOD(AddProbe);
+    static NAN_METHOD(RemoveProbe);
+    static NAN_METHOD(Enable);
+    static NAN_METHOD(Disable);
+    static NAN_METHOD(Fire);
 
     DTraceProvider();
     ~DTraceProvider();

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "engines" : {
         "node" : ">=0.6"
     },
+    "dependencies" : {
+        "nan" : "~0.7.0"
+    },
     "devDependencies": {
         "tap": ">=0.2.0"
     },


### PR DESCRIPTION
Node 0.11 and onwards uses the new V8 which has huge breaking API changes. [NAN](https://github.com/rvagg/nan) is designed to make it easy to support V8 and Node across versions 0.8 to 0.11 and onwards without the need for branching macros. NAN is keeping up-to-date as newer versions of Node 0.11 are released and new breaking changes come upstream from V8.

This PR adds NAN support for compiling against the latest Node 0.11; tests pass.

Let me know if you have any questions, I'd love to get an 0.11 version of dtrace-provider into npm so we can start testing in preparation for the impending 0.12 release.
