### PR TITLE
stub for unsupported platforms does not cover probes used by name

### DIFF
--- a/dtrace-provider.js
+++ b/dtrace-provider.js
@@ -1,10 +1,10 @@
 var DTraceProvider;
 
 function DTraceProviderStub() {}
-DTraceProviderStub.prototype.addProbe = function() {
-    return {
-        'fire': function() { }
-    };
+DTraceProviderStub.prototype.addProbe = function(name) {
+    var p = { 'fire': function () {} };
+    this[name] = p;
+    return (p);
 };
 DTraceProviderStub.prototype.enable = function() {};
 DTraceProviderStub.prototype.fire = function() {};


### PR DESCRIPTION
Here's a test program:

``` javascript
var d = require('./dtrace-provider');
var dtp = d.createDTraceProvider('nodeapp');
dtp.addProbe('probe1');
dtp.enable();

dtp['probe1'].fire(function (f) { return ([]); });
```

On platforms with DTrace, this does what you'd expect:

```
$ sudo dtrace -Z -n 'nodeapp*:::probe1' -c "node ./test.js"
dtrace: description 'nodeapp*:::probe1' matched 0 probes
dtrace: pid 34935 has exited
CPU     ID                    FUNCTION:NAME
  0 256444                    probe1:probe1 

```

On platforms without DTrace, this crashes:

```

/root/node-dtrace-provider/test.js:6
dtp['probe1'].fire(function (f) { return ([]); });
              ^
TypeError: Cannot call method 'fire' of undefined
    at Object.<anonymous> (/root/node-dtrace-provider/test.js:6:15)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
    at startup (node.js:119:16)
    at node.js:906:3
```

With this patch, the stub used on these systems adds the probe to the provider object so that this continues to work.
