### PR TITLE
nan v1.8.4 for io.js 2.0.0 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "node": ">=0.6"
   },
   "dependencies": {
-    "nan": "~1.5.1"
+    "nan": "~1.8.4"
   },
   "devDependencies": {
     "tap": ">=0.2.0"


### PR DESCRIPTION
Compiling dtrace-provider `0.4.0` fails with io.js `2.0.0`:

```
In file included from ../dtrace_provider.cc:1:
In file included from ../dtrace_provider.h:1:
In file included from ../node_modules/nan/nan.h:74:
In file included from ../node_modules/nan/nan_new.h:181:
../node_modules/nan/nan_implementation_12_inl.h:172:66: error: too many arguments to function call, expected at most 2, have 4
  return v8::Signature::New(v8::Isolate::GetCurrent(), receiver, argc, argv);
         ~~~~~~~~~~~~~~~~~~                                      ^~~~~~~~~~
/Users/-/.node-gyp/2.0.0/deps/v8/include/v8.h:4188:3: note: 'New' declared here
  static Local<Signature> New(
  ^
1 error generated.
make: *** [Release/obj.target/DTraceProviderBindings/dtrace_provider.o] Error 1
``` 

This PR updates `nan` to version `1.8.4` allowing compilation with latest io.js version.