### PR TITLE
Bump nan to 1.8.4 adding compatibility for iojs 2.0+

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "node": ">=0.6"
   },
   "dependencies": {
-    "nan": "~1.5.1"
+    "nan": "~1.8.4"
   },
   "devDependencies": {
     "tap": ">=0.2.0"


### PR DESCRIPTION
Doesn't bump version of dtrace-provider.