### PR TITLE
define NPM path which works with node v6.

### DIFF
--- a/scripts/install.js
+++ b/scripts/install.js
@@ -16,7 +16,8 @@ fs.renameSync(src, dst);
 movedFile = true;
 
 //npm_execpath: '/usr/local/lib/node_modules/npm/bin/npm-cli.js',
-var nodegyp = path.join(process.env.npm_execpath,
+var execPath = process.env.npm_execpath || '';
+var nodegyp = path.join(execPath,
                         '..',
                         'node-gyp-bin',
                         'node-gyp');


### PR DESCRIPTION
See #76 

I'm aware this could be wrapped up nicer if npm_execpath is missing or check on node versions, etc.
Would love a comment.