### PR TITLE
Pass extra args to callback via .fire()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,9 @@ dtrace-provider - Changes
 
 ## HISTORY
 
+ * 0.8.0:
+   Support passing additional arguments to probe function via `.fire()`
+
  * 0.7.1:
    Update libusdt for chrisa/libusdt#12 fix
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,9 @@ dtrace-provider - Changes
 
 ## HISTORY
 
+ * 0.7.1:
+   Update libusdt for chrisa/libusdt#12 fix
+
  * 0.7.0: known support for v0.10.47, v0.12.16, v4.6.0.
    Updated NaN dependency to remove warnings on newer Node versions.
 

--- a/dtrace_provider.cc
+++ b/dtrace_provider.cc
@@ -186,7 +186,7 @@ namespace node {
     if (p == NULL)
       return;
 
-    p->_fire(info[1]);
+    p->_fire(info, 1);
 
     info.GetReturnValue().Set(Nan::True());
   }

--- a/dtrace_provider.h
+++ b/dtrace_provider.h
@@ -68,7 +68,7 @@ namespace node {
     static NAN_METHOD(New);
     static NAN_METHOD(Fire);
 
-    v8::Local<Value> _fire(v8::Local<v8::Value>);
+    v8::Local<Value> _fire(Nan::NAN_METHOD_ARGS_TYPE, size_t);
 
     static Nan::Persistent<FunctionTemplate> constructor_template;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dtrace-provider",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Native DTrace providers for node.js applications",
   "keywords": [
     "dtrace",

--- a/package.json
+++ b/package.json
@@ -1,18 +1,20 @@
 {
   "name": "dtrace-provider",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Native DTrace providers for node.js applications",
   "keywords": [
-    "dtrace"
+    "dtrace",
+    "usdt"
   ],
   "homepage": "https://github.com/chrisa/node-dtrace-provider#readme",
+  "license": "BSD-2-Clause",
   "author": {
     "name": "Chris Andrews",
     "email": "chris@nodnol.org"
   },
   "repository": {
     "type": "git",
-    "url": "http://github.com/chrisa/node-dtrace-provider.git"
+    "url": "https://github.com/chrisa/node-dtrace-provider.git"
   },
   "engines": {
     "node": ">=0.10"

--- a/test/args-after-cb-1.test.js
+++ b/test/args-after-cb-1.test.js
@@ -1,0 +1,21 @@
+var test = require('tap').test;
+var format = require('util').format;
+var dtest = require('./dtrace-test').dtraceTest;
+
+test(
+    'probes where .fire() is called with arguments to pass to the callback',
+    dtest(
+        function() { },
+        [
+            'dtrace', '-Zqn',
+            'nodeapp$target:::after1{ printf("%d\\n%s\\n%d\\n", arg0, copyinstr(arg1), arg2); }',
+            '-c', format('node %s/args-after-cb-1_fire.js', __dirname)
+        ],
+        function(t, exit_code, traces) {
+            t.notOk(exit_code, 'dtrace exited cleanly');
+            t.equal(traces[0], '42');
+            t.equal(traces[1], 'forty-two');
+            t.equal(traces[2], '15');
+        }
+    )
+);

--- a/test/args-after-cb-1_fire.js
+++ b/test/args-after-cb-1_fire.js
@@ -1,0 +1,10 @@
+var d = require('../dtrace-provider');
+var provider = d.createDTraceProvider('nodeapp');
+var probe = provider.addProbe('after1', 'int', 'char *', 'int');
+provider.enable();
+
+function fireCb(n1, str2, n2) {
+    return [n1, str2, n2 + 5];
+}
+
+probe.fire(fireCb, 42, 'forty-two', 10);

--- a/test/args-after-cb-2.test.js
+++ b/test/args-after-cb-2.test.js
@@ -1,0 +1,21 @@
+var test = require('tap').test;
+var format = require('util').format;
+var dtest = require('./dtrace-test').dtraceTest;
+
+test(
+    'providers where .fire() is called with arguments to pass to the callback',
+    dtest(
+        function() { },
+        [
+            'dtrace', '-Zqn',
+            'nodeapp$target:::after1{ printf("%d\\n%s\\n%d\\n", arg0, copyinstr(arg1), arg2); }',
+            '-c', format('node %s/args-after-cb-2_fire.js', __dirname)
+        ],
+        function(t, exit_code, traces) {
+            t.notOk(exit_code, 'dtrace exited cleanly');
+            t.equal(traces[0], '42');
+            t.equal(traces[1], 'forty-two');
+            t.equal(traces[2], '15');
+        }
+    )
+);

--- a/test/args-after-cb-2_fire.js
+++ b/test/args-after-cb-2_fire.js
@@ -1,0 +1,10 @@
+var d = require('../dtrace-provider');
+var provider = d.createDTraceProvider('nodeapp');
+provider.addProbe('after1', 'int', 'char *', 'int');
+provider.enable();
+
+function fireCb(n1, str, n2) {
+    return [n1, str, n2 + 5];
+}
+
+provider.fire('after1', fireCb, 42, 'forty-two', 10);


### PR DESCRIPTION
With this change, extra arguments can be passed to the callback given to `.fire()`, similar to how functions like `setImmediate` work. This means that a single top-level function can be passed to `.fire()`, instead of constructing a new closure each time you call it, which takes additional time and memory. (And might be for naught if the probe isn't enabled.) I haven't done much C++ or Nan before, so if anything here can be improved, please let me know.

This compiles and runs on SmartOS and Mac OS X. All of the tests, including the two I've added, pass on both platforms (except for the 2 JSON ones which get skipped on Mac OS X). Additionally, I've run the DTrace tests in [trentm/node-bunyan](https://github.com/trentm/node-bunyan/blob/7300a18583fc4fd1486fc5186985b17c997422fc/test/dtrace.test.js) using these changes.