### PR TITLE
change build to compile on freebsd

### DIFF
--- a/compile.py
+++ b/compile.py
@@ -1,10 +1,18 @@
 {
     'conditions': [
-        ['OS=="mac" or OS=="solaris"', {
-            'variables': {
-              'escaped_root': '<!(printf %q "<(module_root_dir)")',
-            },
-
+        ['OS=="mac" or OS=="solaris" or OS=="freebsd"', {
+            'conditions' : [
+               ['OS=="mac" or OS=="solaris"', {
+               'variables': {
+                 'escaped_root': '<!(printf %q "<(module_root_dir)")',
+               }
+               }],
+               ['OS=="freebsd"', {
+                  'variables' : {
+                     'escaped_root': '<!(printf %s "<(module_root_dir)")'
+                  }
+               }]
+            ],
             # If we are on the Mac, or a Solaris derivative, attempt
             # to build the DTrace provider extension.
 
@@ -16,9 +24,24 @@
                         'dtrace_probe.cc',
                         'dtrace_argument.cc'
                     ],
-                    'include_dirs': [
-                      'libusdt',
-                      '<!(node -e "require(\'nan\')")',
+                    'conditions': [
+                        ['OS=="mac" or OS=="solaris"',
+                           { 'include_dirs': [
+                                'libusdt',
+                                '<!(node -e "require(\'nan\')")',
+                              ]
+                           }
+                        ],
+                        ['OS=="freebsd"',
+                            {  'include_dirs': [
+                                  '/usr/src/cddl/compat/opensolaris/',
+                                  '/usr/src/sys/cddl/compat/opensolaris',
+                                  '/usr/src/sys/cddl/contrib/opensolaris/uts/common/',
+                                  'libusdt',
+                                  '<!(node -e "require(\'nan\')")'
+                                ]
+                            }
+                        ]
                     ],
                     'dependencies': [
                         'libusdt'
@@ -34,9 +57,9 @@
                         'inputs': [''],
                         'outputs': [''],
                         'action_name': 'build_libusdt',
-	      	        'action': [
+                        'action': [
                             'sh', 'libusdt-build.sh'
-		        ]
+                        ]
                     }]
                 }
             ]
@@ -53,6 +76,6 @@
                     'type': 'none'
                 }
             ]
-        }]
+        }],
     ]
 }

--- a/dtrace_provider.h
+++ b/dtrace_provider.h
@@ -16,9 +16,9 @@ extern "C" {
 
 #ifndef __APPLE__
 #include <stdlib.h>
-#endif
 #ifndef __FreeBSD__
 #include <malloc.h>
+#endif
 #endif
 namespace node {
 

--- a/dtrace_provider.h
+++ b/dtrace_provider.h
@@ -16,9 +16,10 @@ extern "C" {
 
 #ifndef __APPLE__
 #include <stdlib.h>
+#endif
+#ifndef __FreeBSD__
 #include <malloc.h>
 #endif
-
 namespace node {
 
   using namespace v8;


### PR DESCRIPTION
Hey all
Change to reinstate the freebsd build 
This targets FreeBSD 11 or a patched 10 and should close https://github.com/chrisa/node-dtrace-provider/issues/30 

outputs on FreeBSD
```
# npm test

> dtrace-provider@0.7.0 test /usr/home/anton/code/builds/node-dtrace-provider
> tap test/*test.js

ok test/32probe-char.test.js .......................... 35/35
ok test/32probe.test.js ............................. 531/531
ok test/add-probes.test.js ............................ 49/49
ok test/basic.test.js ................................... 4/4
ok test/create-destroy.test.js ........................ 13/13
ok test/disambiguation.test.js .......................... 7/7
ok test/dtrace-test.js .................................. 1/1
ok test/enabled-disabled.test.js ...................... 13/13
ok test/enabledagain.test.js ............................ 6/6
ok test/fewer-args-json.test.js ......................... 4/4
ok test/fewer-args.test.js .............................. 5/5
ok test/gc.test.js ...................................... 3/3
ok test/json-args.test.js ............................... 5/5
ok test/more-args.test.js ............................... 4/4
ok test/multiple-json-args.test.js ...................... 3/3
ok test/notenabled.test.js .............................. 2/2
total ............................................... 685/685

ok
```

