### PR TITLE
Reapplied changes for FreeBSD

### DIFF
--- a/compile.py
+++ b/compile.py
@@ -1,10 +1,18 @@
 {
     'conditions': [
-        ['OS=="mac" or OS=="solaris"', {
-            'variables': {
-              'escaped_root': '<!(printf %q "<(module_root_dir)")',
-            },
-
+        ['OS=="mac" or OS=="solaris" or OS=="freebsd"', {
+            'conditions' : [
+               ['OS=="mac" or OS=="solaris"', {
+               'variables': {
+                 'escaped_root': '<!(printf %q "<(module_root_dir)")',
+               }
+               }],
+               ['OS=="freebsd"', {
+                  'variables' : {
+                     'escaped_root': '<!(printf %s "<(module_root_dir)")'
+                  }
+               }]
+            ],
             # If we are on the Mac, or a Solaris derivative, attempt
             # to build the DTrace provider extension.
 
@@ -16,9 +24,24 @@
                         'dtrace_probe.cc',
                         'dtrace_argument.cc'
                     ],
-                    'include_dirs': [
-                      'libusdt',
-                      '<!(node -e "require(\'nan\')")',
+                    'conditions': [
+                        ['OS=="mac" or OS=="solaris"',
+                           { 'include_dirs': [
+                                'libusdt',
+                                '<!(node -e "require(\'nan\')")',
+                              ]
+                           }
+                        ],
+                        ['OS=="freebsd"',
+                            {  'include_dirs': [
+                                  '/usr/src/cddl/compat/opensolaris/',
+                                  '/usr/src/sys/cddl/compat/opensolaris',
+                                  '/usr/src/sys/cddl/contrib/opensolaris/uts/common/',
+                                  'libusdt',
+                                  '<!(node -e "require(\'nan\')")'
+                                ]
+                            }
+                        ]
                     ],
                     'dependencies': [
                         'libusdt'
@@ -34,9 +57,9 @@
                         'inputs': [''],
                         'outputs': [''],
                         'action_name': 'build_libusdt',
-	      	        'action': [
+                        'action': [
                             'sh', 'libusdt-build.sh'
-		        ]
+                        ]
                     }]
                 }
             ]
@@ -53,6 +76,6 @@
                     'type': 'none'
                 }
             ]
-        }]
+        }],
     ]
 }

--- a/dtrace_provider.h
+++ b/dtrace_provider.h
@@ -16,7 +16,9 @@ extern "C" {
 
 #ifndef __APPLE__
 #include <stdlib.h>
+#ifndef __FreeBSD__
 #include <malloc.h>
+#endif
 #endif
 
 namespace node {


### PR DESCRIPTION
This patch reintroduces FreeBSD support for this library.

It updates the the build script to use `%s` instead of `%q` the latter is not supported by default on FreeBSD.

It requires that the base source for dtrace is installed on the build machine. 
This can be found in the standard `base.txz` for the release that being built on. 

It also removes the `malloc.h` include as that has been integrated into `stdlib.h` 

outputs on FreeBSD 10.3 and 11

```
# npm test

> dtrace-provider@0.7.0 test /usr/home/anton/code/builds/node-dtrace-provider
> tap test/*test.js

ok test/32probe-char.test.js .......................... 35/35
ok test/32probe.test.js ............................. 531/531
ok test/add-probes.test.js ............................ 49/49
ok test/basic.test.js ................................... 4/4
ok test/create-destroy.test.js ........................ 13/13
ok test/disambiguation.test.js .......................... 7/7
ok test/dtrace-test.js .................................. 1/1
ok test/enabled-disabled.test.js ...................... 13/13
ok test/enabledagain.test.js ............................ 6/6
ok test/fewer-args-json.test.js ......................... 4/4
ok test/fewer-args.test.js .............................. 5/5
ok test/gc.test.js ...................................... 3/3
ok test/json-args.test.js ............................... 5/5
ok test/more-args.test.js ............................... 4/4
ok test/multiple-json-args.test.js ...................... 3/3
ok test/notenabled.test.js .............................. 2/2
total ............................................... 685/685

ok
```
