### PR TITLE
Fix test failed in MacOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+sudo: true
+language: node_js
+node_js:
+    - "4"
+    - "5"
+script: npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,17 @@
-os:
-  - freebsd
-  - osx
-sudo: true
 language: node_js
+
+os:
+  - osx
+
 node_js:
-    - "4"
-    - "5"
-script: npm test
+  - '0.10'
+  - '0.12'
+  - '4'
+  - '5'
+  - 'node'
+  - 'iojs'
+
+sudo: false
+
+script:
+  - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+os:
+  - freebsd
+  - osx
 sudo: true
 language: node_js
 node_js:

--- a/test/10probe-char.test.js
+++ b/test/10probe-char.test.js
@@ -1,0 +1,31 @@
+var test = require('tap').test;
+var format = require('util').format;
+var dtest = require('./dtrace-test').dtraceTest;
+
+var dscript = 'testlibusdt$target:::10probe{ printf("%s %s %s %s %s %s %s %s %s %s\\n", copyinstr(arg0), copyinstr(arg1), copyinstr(arg2), copyinstr(arg3), copyinstr(arg4), copyinstr(arg5), copyinstr(arg6), copyinstr(arg7), copyinstr(arg8), copyinstr(arg9)); }'
+
+if (process.platform == 'darwin') {
+  test(
+      '10-arg probe',
+      dtest(
+          function() {},
+          ['dtrace', '-Zqn',
+           dscript,
+           '-c', format('node %s/10probe-char_fire.js', __dirname)
+          ],
+          function(t, exit_code, traces) {
+              t.notOk(exit_code, 'dtrace exited cleanly');
+              t.equal(traces.length, 1);
+
+              var letters = ['a', 'b', 'c', 'd', 'e',
+                             'f', 'g', 'h', 'i', 'j']
+
+              var traced = traces[0].split(' ');
+              for (var i = 0; i < 10; i++) {
+                  t.equal(traced[i], letters[i],
+                          format('arg%d of a 10-arg probe firing should be %s', i, letters[i]));
+              }
+          }
+      )
+  );
+}

--- a/test/10probe-char_fire.js
+++ b/test/10probe-char_fire.js
@@ -1,0 +1,18 @@
+// see 32probe-char.test.js
+
+var d = require('../dtrace-provider');
+
+var provider = d.createDTraceProvider("testlibusdt");
+var probe = provider.addProbe(
+    "10probe",
+    "char *", "char *", "char *", "char *", "char *",
+    "char *", "char *", "char *", "char *", "char *");
+provider.enable();
+
+var letters = ['a', 'b', 'c', 'd', 'e',
+               'f', 'g', 'h', 'i', 'j']
+
+probe.fire(function(p) {
+    return letters;
+});
+

--- a/test/10probe.test.js
+++ b/test/10probe.test.js
@@ -1,0 +1,31 @@
+var test = require('tap').test;
+var format = require('util').format;
+var dtest = require('./dtrace-test').dtraceTest;
+
+if (process.platform == 'darwin') {
+  test(
+      '10-arg probe',
+      dtest(
+          function() {},
+          ['dtrace', '-Zqn',
+           'testlibusdt$target:::10probe{ printf("%d %d %d %d %d %d %d %d %d %d\\n", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) }',
+          '-c', format('node %s/10probe_fire.js', __dirname)
+          ],
+          function(t, exit_code, traces) {
+            console.log(traces)
+              t.notOk(exit_code, 'dtrace exited cleanly');
+              t.equal(traces.length, 10, 'got 10 traces');
+
+              var args = [];
+              for (var i = 1; i <= 10; i++) {
+                  args.push(i);
+                  var traced = traces[i - 1].split(' ');
+                  args.forEach(function(n) {
+                      t.equal(traced[n - 1], [n].toString(),
+                              format('arg%d of a %d-arg probe firing should be %d', n - 1, i, n));
+                  });
+              }
+          }
+      )
+  );
+}

--- a/test/10probe_fire.js
+++ b/test/10probe_fire.js
@@ -1,0 +1,19 @@
+// see 32probe.test.js
+
+var d = require('../dtrace-provider');
+
+var provider = d.createDTraceProvider("testlibusdt");
+var probe = provider.addProbe(
+    "10probe",
+    "int", "int", "int", "int", "int",
+    "int", "int", "int", "int", "int")
+
+provider.enable();
+
+var args = [];
+for (var n = 1; n <= 10; n++) {
+    args.push(n);
+    probe.fire(function(p) {
+        return args;
+    });
+}

--- a/test/32probe-char.test.js
+++ b/test/32probe-char.test.js
@@ -3,6 +3,9 @@ var format = require('util').format;
 var dtest = require('./dtrace-test').dtraceTest;
 
 if (process.platform == 'darwin') {
+  return
+}
+if (process.platform == 'darwin') {
     var dscript = 'testlibusdt*:::32probe{ printf("%s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s\\n", copyinstr((user_addr_t)args[0]), copyinstr((user_addr_t)args[1]), copyinstr((user_addr_t)args[2]), copyinstr((user_addr_t)args[3]), copyinstr((user_addr_t)args[4]), copyinstr((user_addr_t)args[5]), copyinstr((user_addr_t)args[6]), copyinstr((user_addr_t)args[7]), copyinstr((user_addr_t)args[8]), copyinstr((user_addr_t)args[9]), copyinstr((user_addr_t)args[10]), copyinstr((user_addr_t)args[11]), copyinstr((user_addr_t)args[12]), copyinstr((user_addr_t)args[13]), copyinstr((user_addr_t)args[14]), copyinstr((user_addr_t)args[15]), copyinstr((user_addr_t)args[16]), copyinstr((user_addr_t)args[17]), copyinstr((user_addr_t)args[18]), copyinstr((user_addr_t)args[19]), copyinstr((user_addr_t)args[20]), copyinstr((user_addr_t)args[21]), copyinstr((user_addr_t)args[22]), copyinstr((user_addr_t)args[23]), copyinstr((user_addr_t)args[24]), copyinstr((user_addr_t)args[25]), copyinstr((user_addr_t)args[26]), copyinstr((user_addr_t)args[27]), copyinstr((user_addr_t)args[28]), copyinstr((user_addr_t)args[29]), copyinstr((user_addr_t)args[30]), copyinstr((user_addr_t)args[31])); }';
 }
 else {
@@ -26,7 +29,7 @@ test(
                 "char *", "char *", "char *", "char *", "char *", "char *", "char *", "char *");
             provider.enable();
         },
-        ['dtrace', '-qn', 
+        ['dtrace', '-qn',
          dscript,
          '-c', format('node %s/32probe-char_fire.js', __dirname)
         ],
@@ -38,7 +41,7 @@ test(
                            'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p',
                            'q', 'r', 's', 't', 'u', 'v', 'w', 'x',
                            'y', 'z', 'A', 'B', 'C', 'D', 'E', 'F'];
-            
+
             var traced = traces[0].split(' ');
             for (var i = 0; i < 32; i++) {
                 t.equal(traced[i], letters[i],

--- a/test/32probe.test.js
+++ b/test/32probe.test.js
@@ -2,6 +2,9 @@ var test = require('tap').test;
 var format = require('util').format;
 var dtest = require('./dtrace-test').dtraceTest;
 
+if (process.platform == 'darwin') {
+  return
+}
 test(
     '32-arg probe',
     dtest(
@@ -18,14 +21,14 @@ test(
                                           "int", "int", "int", "int", "int", "int", "int", "int");
             provider.enable();
         },
-        ['dtrace', '-qn', 
+        ['dtrace', '-qn',
          'testlibusdt*:::32probe{ printf("%d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d\\n", args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8], args[9], args[10], args[11], args[12], args[13], args[14], args[15], args[16], args[17], args[18], args[19], args[20], args[21], args[22], args[23], args[24], args[25], args[26], args[27], args[28], args[29], args[30], args[31]) }',
         '-c', format('node %s/32probe_fire.js', __dirname)
         ],
         function(t, exit_code, traces) {
             t.notOk(exit_code, 'dtrace exited cleanly');
             t.equal(traces.length, 32, 'got 32 traces');
-            
+
             var args = [];
             for (var i = 1; i <= 32; i++) {
                 args.push(i);

--- a/test/add-probes.test.js
+++ b/test/add-probes.test.js
@@ -8,7 +8,7 @@ test(
         function() { },
         [
             'dtrace', '-Zqn',
-            'nodeapp*:::{ printf("%d\\n", arg0); }',
+            'nodeapp$target:::{ printf("%d\\n", arg0); }',
             '-c', format('node %s/add-probes_fire.js', __dirname)
         ],
         function(t, exit_code, traces) {

--- a/test/create-destroy.test.js
+++ b/test/create-destroy.test.js
@@ -8,7 +8,7 @@ test(
         function() { },
         [
             'dtrace', '-Zqn',
-            'nodeapp*:::{ printf("%d\\n", arg0); }',
+            'nodeapp$target:::{ printf("%d\\n", arg0); }',
             '-c', format('node %s/create-destroy_fire.js', __dirname)
         ],
         function(t, exit_code, traces) {

--- a/test/disambiguation.test.js
+++ b/test/disambiguation.test.js
@@ -7,8 +7,8 @@ test(
     dtest(
         function() { },
         [
-            'dtrace', '-Zqn', 
-            'test*:::{printf("%s\\n%s\\n", probename, probemod)}',
+            'dtrace', '-Zqn',
+            'test$target:::{printf("%s\\n%s\\n", probename, probemod)}',
             '-c', format('node %s/disambiguation_fire.js', __dirname)
         ],
         function(t, exit_code, traces) {

--- a/test/enabled-disabled.test.js
+++ b/test/enabled-disabled.test.js
@@ -7,8 +7,8 @@ test(
     dtest(
         function() { },
         [
-            'dtrace', '-Zqn', 
-            'nodeapp*:::{ printf("%d\\n", arg0); }',
+            'dtrace', '-Zqn',
+            'nodeapp$target:::{ printf("%d\\n", arg0); }',
             '-c', format('node %s/enabled-disabled_fire.js', __dirname)
         ],
         function(t, exit_code, traces) {


### PR DESCRIPTION
I found in My MacOS run `npm test` failed and try to find failed reason

before I create a issue https://github.com/chrisa/node-dtrace-provider/issues/83 and desc failed reason

Main modify as follow:
```
1. In My MacOS `DTrace` probe support USDT_ARG_MAX  is 10
 
2. Change DTrace script grammar, eg "nodeapp*:::"  to "nodeapp$target"
```