### PR TITLE
Fix for building on node v10

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "node": ">=0.10"
   },
   "dependencies": {
-    "nan": "^2.3.3"
+    "nan": "^2.10.0"
   },
   "devDependencies": {
     "tap": "0.7.1"

--- a/src/dtrace_provider.cc
+++ b/src/dtrace_provider.cc
@@ -86,7 +86,7 @@ namespace node {
     // create a DTraceProbe object
     v8::Local<Function> klass =
         Nan::New<FunctionTemplate>(DTraceProbe::constructor_template)->GetFunction();
-    v8::Local<Object> pd = klass->NewInstance();
+    v8::Local<Object> pd = Nan::NewInstance(klass).ToLocalChecked();
 
     // store in provider object
     DTraceProbe *probe = Nan::ObjectWrap::Unwrap<DTraceProbe>(pd->ToObject());


### PR DESCRIPTION
This patch implements the Nan wrapper for New Instance
Test ran against v6 and v10 of node on FreeBSD 12 Current  
```
> dtrace-provider@0.8.6 test /usr/home/anton/code/node-dtrace-provider
> tap test/*.test.js

ok test/32probe-char.test.js .......................... 35/35
ok test/32probe.test.js ............................. 531/531
ok test/add-probes.test.js ............................ 49/49
ok test/args-after-cb-1.test.js ......................... 5/5
ok test/args-after-cb-2.test.js ......................... 5/5
ok test/basic.test.js ................................... 4/4
ok test/create-destroy.test.js ........................ 13/13
ok test/disambiguation.test.js .......................... 7/7
ok test/enabled-disabled.test.js ...................... 13/13
ok test/enabledagain.test.js ............................ 6/6
ok test/fewer-args-json.test.js ......................... 4/4
ok test/fewer-args.test.js .............................. 5/5
ok test/gc-provider.test.js ............................. 3/3
ok test/gc.test.js ...................................... 3/3
ok test/json-args.test.js ............................... 5/5
ok test/more-args.test.js ............................... 4/4
ok test/multiple-json-args.test.js ...................... 3/3
ok test/notenabled.test.js .............................. 2/2
total ............................................... 697/697

ok
```