### PR TITLE
Nodejs 12 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "node": ">=0.10"
   },
   "dependencies": {
-    "nan": "^2.10.0"
+    "nan": "^2.14.0"
   },
   "devDependencies": {
     "tap": "0.7.1"

--- a/src/dtrace_probe.cc
+++ b/src/dtrace_probe.cc
@@ -28,7 +28,7 @@ namespace node {
 
     Nan::SetPrototypeMethod(t, "fire", DTraceProbe::Fire);
 
-    target->Set(Nan::New<String>("DTraceProbe").ToLocalChecked(), t->GetFunction());
+    target->Set(Nan::New<String>("DTraceProbe").ToLocalChecked(), Nan::GetFunction(t).ToLocalChecked());
   }
 
   NAN_METHOD(DTraceProbe::New) {
@@ -68,7 +68,12 @@ namespace node {
     }
 
     Local<Function> cb = Local<Function>::Cast(argsinfo[fnidx]);
-    Local<Value> probe_args = cb->Call(this->handle(), cblen, cbargs);
+    Nan::MaybeLocal<Value> maybe = Nan::Call(cb, this->handle(), cblen, cbargs);
+    if (maybe.IsEmpty()) {
+      Nan::ThrowTypeError("Failed to invoke fire callback");
+      return Nan::Undefined();
+    }
+    Local<Value> probe_args = maybe.ToLocalChecked();
 
     delete [] cbargs;
 


### PR DESCRIPTION
This PR aims to make `node-dtrace-provider` compatible with changes in v8 and allows the usage of the library with Node.JS 12. I ran the tests both for master with node `10.15.2` and on the branch with node `12.5.0` and on both I had 670 passing tests out of 699 total tests. I tested on MacOS 10.14.5 and disable SIP by executing `csrutil disable` in recovery mode. @chrisa do you have a continuous integration setup where I could test this PR.