### PR TITLE
build directory fixed

### DIFF
--- a/dtrace-provider.js
+++ b/dtrace-provider.js
@@ -15,7 +15,7 @@ var err = null;
 
 for (var i = 0; i < builds.length; i++) {
     try {
-        var binding = require('./src/build/' + builds[i] + '/DTraceProviderBindings');
+        var binding = require('./build/' + builds[i] + '/DTraceProviderBindings');
         DTraceProvider = binding.DTraceProvider;
         break;
     } catch (e) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "dtrace-provider",
+  "name": "dtrace-provider-new",
   "version": "0.8.8",
-  "description": "Native DTrace providers for node.js applications",
+  "description": "Native DTrace providers for node.js applications with build directory fixed",
   "keywords": [
     "dtrace",
     "usdt"
@@ -9,12 +9,12 @@
   "homepage": "https://github.com/chrisa/node-dtrace-provider#readme",
   "license": "BSD-2-Clause",
   "author": {
-    "name": "Chris Andrews",
-    "email": "chris@nodnol.org"
+    "name": "Mukul Kumar",
+    "email": "mukulk133@gmail.com"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/chrisa/node-dtrace-provider.git"
+    "url": "https://github.com/developerKumar/node-dtrace-provider"
   },
   "engines": {
     "node": ">=0.10"


### PR DESCRIPTION
Fixed:
var binding = require('./src/build/' + builds[i] + '/DTraceProviderBindings');
to
 var binding = require('./build/' + builds[i] + '/DTraceProviderBindings');

As it was giving console compile warning in react typescript project.
Warning was:

./node_modules/dtrace-provider/dtrace-provider.js
Module not found: Can't resolve './src/build' in '/home/mukulkumar/Desktop/Mukul/web-frontend/node_modules/dtrace-provider