### PR TITLE
Take in env for libusdt build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -59,7 +59,7 @@ buildUSDT() {
     fi
 
     # Build libusdt.
-    $MAKE -C libusdt clean all
+    $MAKE -e -C libusdt clean all
 }
 
 buildNDTP() {


### PR DESCRIPTION
This lets users over-ride libusdt build settings via npm install
(Needs the updated libusdt to fully work.)