### PR TITLE
Specify supported CPUs in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
   ],
   "homepage": "https://github.com/chrisa/node-dtrace-provider#readme",
   "license": "BSD-2-Clause",
+  "cpu": [
+    "ia32",
+    "x64"
+  ],
   "author": {
     "name": "Chris Andrews",
     "email": "chris@nodnol.org"


### PR DESCRIPTION
libusdt, and therefore, node-dtrace-provider, only supports 32-bit and 64-bit x86.

This change makes this explicit in package.json and should stop other packages from pulling it in as an optional dependency on other cpus.
It should solve my instance of https://github.com/chrisa/node-dtrace-provider/issues/118 that I run into on a Mac M1